### PR TITLE
Add a checking logic to delete miniconda directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,7 +188,8 @@ RUN cd ~ && \
     /opt/miniconda/bin/conda clean -y --all
 
 # Remove tests directory containing test private keys
-RUN rm -r /opt/miniconda/pkgs/conda-content-trust-*/info/test/tests
+# conda clean will clean this directory but just in case, it will check the directory existence and remove it
+RUN if [ -d " /opt/miniconda/pkgs/conda-content-trust-*/info/test/tests" ]; then rm -rf "/opt/miniconda/pkgs/conda-content-trust-*/info/test/tests"; fi
 
 ENV PATH=/opt/miniconda/bin:$PATH
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Openshift ci failed because it tried to delete the non-existed directory.
~~~
RUN rm -r /opt/miniconda/pkgs/conda-content-trust-*/info/test/tests
~~~
This directory was deleted by `conda clean` command right before the RUN command
~~~
/opt/miniconda/bin/conda clean -y --all
~~~ 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It can not be tested manually. OpenShift ci can test this.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
