### PR TITLE
re-enable http generate endpoint

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -378,9 +378,8 @@ async fn do_run<B: BatchType>(
 
     // Create router
     let app = Router::new()
-        // Disabling HTTP generate endpoint for now
-        //.route("/generate", post(generate))
-        //.layer(Extension(shared_state.clone()))
+        .route("/generate", post(generate))
+        .layer(Extension(shared_state.clone()))
         .route("/health", get(health))
         .layer(Extension(health_ext))
         .route("/metrics", get(metrics))


### PR DESCRIPTION

## How Has This Been Tested?

Spin up text generations server:

```bash
text-generation-launcher --model-name ./flan-t5-small-caikit/artifacts
```
### Using curl

```bash
curl --header "Content-Type: application/json"  --data '{"inputs": "complete this text"}' localhost:3000/generate
```
Result: 
```console
[{"generated_text":"a sluggish sluggish sluggish sl"}]
```
### Using httpie
Hit the serve using [httpie](https://httpie.io/):

```bash
http :3000/generate inputs="complete this text"
```
Result:
```console 
HTTP/1.1 200 OK
content-length: 54
content-type: application/json
date: Tue, 09 Jan 2024 16:01:31 GMT
x-inference-time: 175
x-queue-time: 0
x-time-per-token: 8
x-total-time: 175
x-validation-time: 0

[
    {
        "generated_text": "a sluggish sluggish sluggish sl"
    }
]
```


