### PR TITLE
Dockerfile: bump ubi version to 9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Global Args #################################################################
-ARG BASE_UBI_IMAGE_TAG=9.3-1610
+ARG BASE_UBI_IMAGE_TAG=9.4
 ARG PROTOC_VERSION=25.3
 ARG PYTORCH_INDEX="https://download.pytorch.org/whl"
 # ARG PYTORCH_INDEX="https://download.pytorch.org/whl/nightly"


### PR DESCRIPTION
Related: https://github.com/red-hat-data-services/text-generation-inference/pull/50