### PR TITLE
Add script to wait for the model to appear when using KServe Modelcar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -313,6 +313,7 @@ RUN pip list -v --disable-pip-version-check --no-python-version-warning
 COPY --from=router-builder /usr/local/cargo/bin/text-generation-router /usr/local/bin/text-generation-router
 # Install launcher
 COPY --from=launcher-builder /usr/local/cargo/bin/text-generation-launcher /usr/local/bin/text-generation-launcher
+COPY --chown=0:0 --chmod=554 scripts/wait-modelcar.sh /usr/local/bin/wait-modelcar.sh
 
 ENV PORT=3000 \
     GRPC_PORT=8033 \
@@ -330,4 +331,5 @@ USER tgis
 EXPOSE ${PORT}
 EXPOSE ${GRPC_PORT}
 
+ENTRYPOINT ["wait-modelcar.sh"]
 CMD text-generation-launcher

--- a/scripts/wait-modelcar.sh
+++ b/scripts/wait-modelcar.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${MODEL_INIT_MODE}" = "async" ] ; then
+  echo "Waiting for model files (modelcar) to be present..."
+  until test -e /mnt/models; do
+    sleep 1
+  done
+
+  echo "Model files are now available."
+fi
+
+echo "Starting model server..."
+eval $@
+


### PR DESCRIPTION
When using OCI containers for model storage in KServe (modelcar), there is the possibility that the model server starts before the model has been fully downloaded. When this happens, the model server would terminate with error because the model path is empty.

This adds a small script to wait for the cluster to fully download the model container before invoking the model server. The waiting is triggered when the MODEL_INIT_MODE environment variable is set to "async".

