### PR TITLE
Upgrade UBI to 9.5 (#111)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Global Args #################################################################
-ARG BASE_UBI_IMAGE_TAG=9.4-1214
+ARG BASE_UBI_IMAGE_TAG=9.5
 ARG PROTOC_VERSION=25.3
 ARG PYTORCH_INDEX="https://download.pytorch.org/whl"
 # ARG PYTORCH_INDEX="https://download.pytorch.org/whl/nightly"


### PR DESCRIPTION
#### Motivation

[Describe why this change is needed]
UBI 9.4 shows at least one or more high/important
[CVEs](https://quay.io/repository/modh/text-generation-inference/manifest/sha256:bb36bb41cc744a8ff94d537f74c228e8b4e17c2468c50ccd89fc21ecc3940a70?tab=vulnerabilities). UBI 9.5 has those vulnerabilities resolved.

#### Modifications

[Describe the code changes]
UBI base image is updated to 9.5 in Dockerfile

#### Result

[Describe how the changes affects existing behavior and how to test it] Should not change/affect existing behavior. Standard tests should work fine.

#### Related Issues
Resolves https://issues.redhat.com/browse/RHOAIENG-16987 


[Resolves #123]

#### Motivation

[Describe why this change is needed]

#### Modifications

[Describe the code changes]

#### Result

[Describe how the changes affects existing behavior and how to test it]

#### Related Issues

[Resolves #123]
